### PR TITLE
修复离线运行缺少`OpenJDK-23`镜像文件 导致的中断

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,21 @@
 
 # 离线运行
 
-1. 下载文件 [Dialer.zip](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/Dialer.zip) 和 [auto.sh](https://raw.githubusercontent.com/dogliu666/ESurfingDialer-For-Docker/refs/heads/main/auto.sh)
-2. 将 所下载的两个文件 上传至 OpenWrt路由器 `/root`下, 其文件结构为
+1. 下载文件 [Dialer.zip](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/Dialer.zip) + [auto.sh](https://raw.githubusercontent.com/dogliu666/ESurfingDialer-For-Docker/refs/heads/main/auto.sh) + [openjdk-23.tar](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/openjdk-23.tar) 总计3个文件上传至OpenWrt设备上
+
+2. 将 所下载的3个文件 上传至 OpenWrt路由器 `/root`下, 其文件结构为
 ```
 .
 ├── auto.sh
+├── openjdk-23.tar
 └── Dialer.zip 
 ```
+
 3. 使用指令以离线构建Docker容器
+```bash
+docker load -i openjdk-23.tar
+```
+
 ```bash
 bash  auto.sh
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESurfingDialer-For-Docker 
 
-广东电信天翼校园登录认证脚本，适用于 OpenWrt，通过 Docker 一键搭建。
+广东电信天翼校园登录认证脚本，适用于 OpenWrt 和 iStoreOS，通过 Docker 一键搭建。
 
 ## 项目简介
 
@@ -10,7 +10,7 @@
 - [x] 在线脚本
 - [x] 离线脚本
 
-# 若路由器已接入互联网,选择`在线运行`, 若路由器未接入互联网, 选择`离线运行`
+# 若路由器已接入互联网,选择[在线运行](https://github.com/dogliu666/ESurfingDialer-For-Docker#%E5%9C%A8%E7%BA%BF%E8%BF%90%E8%A1%8C), 若路由器未接入互联网, 选择[离线运行](https://github.com/dogliu666/ESurfingDialer-For-Docker#%E7%A6%BB%E7%BA%BF%E8%BF%90%E8%A1%8C)
 
 # 在线运行
 
@@ -22,9 +22,9 @@
 
 # 离线运行
 
-1. 下载文件 [Dialer.zip](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/Dialer.zip) + [auto.sh](https://raw.githubusercontent.com/dogliu666/ESurfingDialer-For-Docker/refs/heads/main/auto.sh) + [openjdk-23.tar](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/openjdk-23.tar) 总计3个文件上传至OpenWrt设备上
+1. 下载文件 [Dialer.zip](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/Dialer.zip) + [auto.sh](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/auto.sh) + [openjdk-23.tar](https://github.com/dogliu666/ESurfingDialer-For-Docker/releases/download/Latest/openjdk-23.tar) **总计3个文件**上传至设备上
 
-2. 将 所下载的3个文件 上传至 OpenWrt路由器 `/root`下, 其文件结构为
+2. 将 所下载的3个文件 上传至 设备 `/root`下，其文件结构为
 ```
 .
 ├── auto.sh
@@ -33,13 +33,14 @@
 ```
 
 3. 使用指令以离线构建Docker容器
-```bash
-docker load -i openjdk-23.tar
-```
-
-```bash
-bash  auto.sh
-```
+- 首先加载镜像文件`openjdk-23`
+   ```bash
+   docker load -i openjdk-23.tar
+   ```
+- 然后运行自动脚本
+   ```bash
+   bash  auto.sh
+   ```
 **在询问`文件 Dialer.zip 已存在。是否删除并重新下载？(y/n):`时, 选择 `n`**
 
 ## 脚本运行时


### PR DESCRIPTION
#2 修复了当用户在Docker中缺少`openjdk:23`镜像文件造成的中断
属于测试过程中的疏忽
已修复